### PR TITLE
Allowing Model And Model ID To Be Passed Through Partial 'locals' Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@ Demo: [heroku app](http://rails-admin-material.herokuapp.com/posts/)
 
 - Add to application layout (in body) (erb example): `<%= render 'live_edit/ra_live_editor' %>`
 
-
-- *[Optional]* Instead of letting the model name being guest from the controller name that rendered the view you can render the live_editor partial passing the **target_model** and/or the **target_model_id** like this: `<%= render partial: 'live_edit/ra_live_editor', locals: { target_model: 'Post', target_model_id: 42 } %>` 
-
+- *[Optional]* Instead of letting the model name being guest from the controller name that rendered the view you can render the live_editor partial passing the **target_model** and/or the **target_model_id** like this: `<%= render partial: 'live_edit/ra_live_editor', locals: { target_model: 'post', target_model_id: 42 } %>` 
 
 - Edit or create *app/assets/javascripts/rails_admin/custom/ui.js* and add: `//= require rails_admin/plugins/live_edit/ui.js`
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Demo: [heroku app](http://rails-admin-material.herokuapp.com/posts/)
 
 - Add to application layout (in body) (erb example): `<%= render 'live_edit/ra_live_editor' %>`
 
+
+- *[Optional]* Instead of letting the model name being guest from the controller name that rendered the view you can render the live_editor partial passing the **target_model** and/or the **target_model_id** like this: `<%= render partial: 'live_edit/ra_live_editor', locals: { target_model: 'Post', target_model_id: 42 } %>` 
+
+
 - Edit or create *app/assets/javascripts/rails_admin/custom/ui.js* and add: `//= require rails_admin/plugins/live_edit/ui.js`
 
 ## Notes

--- a/app/views/live_edit/_ra_live_editor.html.haml
+++ b/app/views/live_edit/_ra_live_editor.html.haml
@@ -3,10 +3,10 @@
   ra_le_model = false
   if defined?( current_user ) && current_user
     ra_logged = true
-    model = controller_name.singularize
+    model = target_model || controller_name.singularize
     if RailsAdmin.config && RailsAdmin.config.models.map{ |mod| mod.abstract_model.model_name.underscore }.include?( model )
       ra_le_model = model
-      ra_le_id = params[:id]
+      ra_le_id = target_model_id || params[:id]
     end
     if RailsAdmin.config.main_app_name
       if RailsAdmin.config.main_app_name.is_a? Proc

--- a/app/views/live_edit/_ra_live_editor.html.haml
+++ b/app/views/live_edit/_ra_live_editor.html.haml
@@ -3,10 +3,10 @@
   ra_le_model = false
   if defined?( current_user ) && current_user
     ra_logged = true
-    model = target_model || controller_name.singularize
+    model = local_assigns[:target_model] || controller_name.singularize
     if RailsAdmin.config && RailsAdmin.config.models.map{ |mod| mod.abstract_model.model_name.underscore }.include?( model )
       ra_le_model = model
-      ra_le_id = target_model_id || params[:id]
+      ra_le_id = local_assigns[:target_model_id] || params[:id]
     end
     if RailsAdmin.config.main_app_name
       if RailsAdmin.config.main_app_name.is_a? Proc


### PR DESCRIPTION
Sometimes a model cannot be guessed from its controller. Also the model instance sometimes cannot be retrieved through `params[:id]`. Due to that, allow the dev to pass **model name** and **model instance id** can be helpful.  